### PR TITLE
feat: open journal photo log with lightbox gallery

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -15,7 +15,7 @@
  */
 
 import { writeFileSync } from 'node:fs'
-import { MATERIALS, BUDGET_ITEMS, JOURNAL_SLOTS } from '../src/lib/mock-data'
+import { MATERIALS, BUDGET_ITEMS } from '../src/lib/mock-data'
 
 const args  = process.argv.slice(2)
 const print = args.includes('--print')
@@ -97,20 +97,10 @@ for (const [i, item] of BUDGET_ITEMS.entries()) {
   }
 }
 
-// Journal — seed from mock-data, merge photo URLs
+// Journal is now an open list of entries created at runtime; not seeded here.
+// Legacy slot photos are converted to entries by the in-app migration in
+// useJournal() on first signed-in load.
 const journal: Record<string, object> = {}
-for (const slot of JOURNAL_SLOTS) {
-  journal[slot.id] = {
-    id:       slot.id,
-    label:    slot.label,
-    phase:    slot.phase,
-    imageUrl: (existingPhotos as Record<string, string>)[slot.id] ?? null,
-  }
-}
-const preserved = JOURNAL_SLOTS.filter(s => (existingPhotos as Record<string, string>)[s.id])
-if (preserved.length) {
-  console.log(`  Preserved photos: ${preserved.map(s => s.id).join(', ')}`)
-}
 
 // ─── Output ───────────────────────────────────────────────────────────────────
 

--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -8,7 +8,7 @@
  *   VITE_DB_ROOT=garden-test FIREBASE_DB_SECRET=<secret> npx tsx scripts/seed-test-db.ts
  */
 
-import { PHASES, BUDGET_ITEMS, MATERIALS, JOURNAL_SLOTS } from '../src/lib/mock-data'
+import { PHASES, BUDGET_ITEMS, MATERIALS } from '../src/lib/mock-data'
 
 const DB_ROOT   = process.env.VITE_DB_ROOT ?? 'garden-test'
 const SECRET    = process.env.FIREBASE_DB_SECRET
@@ -66,10 +66,5 @@ for (const [i, m] of MATERIALS.entries()) {
 }
 console.log(`  ✓ ${DB_ROOT}/materials (${MATERIALS.length} materials)`)
 
-// Journal
-for (const s of JOURNAL_SLOTS) {
-  await put(`journal/${s.id}`, { id: s.id, label: s.label, phase: s.phase })
-}
-console.log(`  ✓ ${DB_ROOT}/journal (${JOURNAL_SLOTS.length} slots)`)
-
+// Journal — seeded empty; entries are created at runtime via uploads.
 console.log('Done.')

--- a/src/features/journal/JournalLightbox.tsx
+++ b/src/features/journal/JournalLightbox.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { JournalEntry } from '../../types'
+import { ConfirmModal } from '../../design-system'
+
+interface JournalLightboxProps {
+  entries:          JournalEntry[]
+  index:            number
+  onIndexChange:    (next: number) => void
+  onClose:          () => void
+  onDelete:         (id: string) => void
+  onCaptionChange:  (id: string, caption: string) => void
+}
+
+export function JournalLightbox({
+  entries, index, onIndexChange, onClose, onDelete, onCaptionChange,
+}: JournalLightboxProps) {
+  const entry = entries[index]
+  const [editing, setEditing]       = useState(false)
+  const [draft, setDraft]           = useState('')
+  const [confirming, setConfirming] = useState(false)
+
+  useEffect(() => { setEditing(false) }, [index])
+
+  const hasPrev = index > 0
+  const hasNext = index < entries.length - 1
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (editing || confirming) return
+      if (e.key === 'ArrowLeft'  && hasPrev) onIndexChange(index - 1)
+      if (e.key === 'ArrowRight' && hasNext) onIndexChange(index + 1)
+      if (e.key === 'Escape')                onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [index, hasPrev, hasNext, editing, confirming, onIndexChange, onClose])
+
+  if (!entry) return null
+
+  function startEditing() {
+    setDraft(entry.caption ?? '')
+    setEditing(true)
+  }
+
+  function commitCaption() {
+    setEditing(false)
+    if ((entry.caption ?? '') !== draft) onCaptionChange(entry.id, draft)
+  }
+
+  return createPortal(
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex flex-col">
+      <div
+        className="absolute inset-0 bg-black/85"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative z-10 flex items-center justify-between px-4 py-3 text-garden-text/70">
+        <span className="text-xs">
+          {index + 1} / {entries.length}
+        </span>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setConfirming(true)}
+            className="text-xs text-garden-text/60 hover:text-[#9E4E24]"
+            aria-label="Delete photo"
+          >
+            Delete
+          </button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-2xl leading-none text-garden-text/50 hover:text-garden-text"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <div className="relative z-10 flex flex-1 items-center justify-center px-4">
+        <button
+          onClick={() => hasPrev && onIndexChange(index - 1)}
+          disabled={!hasPrev}
+          aria-label="Previous photo"
+          className="absolute left-2 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-black/40 text-2xl text-garden-text/80 transition-opacity hover:bg-black/60 disabled:opacity-20 sm:left-6"
+        >
+          ‹
+        </button>
+
+        <img
+          src={entry.imageUrl}
+          alt={entry.caption ?? 'Journal photo'}
+          className="max-h-[75vh] max-w-full rounded object-contain"
+          onClick={e => e.stopPropagation()}
+        />
+
+        <button
+          onClick={() => hasNext && onIndexChange(index + 1)}
+          disabled={!hasNext}
+          aria-label="Next photo"
+          className="absolute right-2 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-black/40 text-2xl text-garden-text/80 transition-opacity hover:bg-black/60 disabled:opacity-20 sm:right-6"
+        >
+          ›
+        </button>
+      </div>
+
+      <div
+        className="relative z-10 px-4 py-4 sm:px-12"
+        onClick={e => e.stopPropagation()}
+      >
+        {editing ? (
+          <input
+            autoFocus
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onBlur={commitCaption}
+            onKeyDown={e => {
+              if (e.key === 'Enter') commitCaption()
+              if (e.key === 'Escape') { setEditing(false); setDraft(entry.caption ?? '') }
+            }}
+            placeholder="Add a caption…"
+            className="w-full rounded border border-amber/40 bg-transparent px-3 py-2 text-sm text-garden-text placeholder:text-garden-text/30 focus:outline-none"
+            data-testid="journal-caption-input"
+          />
+        ) : (
+          <button
+            onClick={startEditing}
+            className="block w-full rounded px-3 py-2 text-left text-sm text-garden-text/80 hover:bg-white/5"
+            data-testid="journal-caption-display"
+          >
+            {entry.caption || <span className="italic text-garden-text/30">Add a caption…</span>}
+          </button>
+        )}
+      </div>
+
+      <ConfirmModal
+        open={confirming}
+        title="Delete photo?"
+        body="This will permanently remove the photo from the journal."
+        onConfirm={() => { setConfirming(false); onDelete(entry.id) }}
+        onCancel={() => setConfirming(false)}
+      />
+    </div>,
+    document.body,
+  )
+}

--- a/src/features/journal/JournalPage.tsx
+++ b/src/features/journal/JournalPage.tsx
@@ -1,5 +1,8 @@
-import { PageHeader, Skeleton } from '../../design-system'
+import { useEffect, useRef, useState } from 'react'
+import { Button, EmptyState, PageHeader, Skeleton } from '../../design-system'
 import { useJournal } from '../../lib/firebase/hooks'
+import { imageFromClipboard } from '../../lib/firebase/storage'
+import { JournalLightbox } from './JournalLightbox'
 
 function JournalSkeleton() {
   return (
@@ -11,40 +14,139 @@ function JournalSkeleton() {
   )
 }
 
-function PhotoSlot({ label, phase, imageUrl }: { label: string; phase: string; imageUrl?: string }) {
-  return (
-    <div className="group relative aspect-[3/2] overflow-hidden rounded border border-white/10 bg-[#1c2017]">
-      {imageUrl ? (
-        <img src={imageUrl} alt={label} className="h-full w-full object-cover" />
-      ) : (
-        <div className="flex h-full flex-col items-center justify-center gap-2 p-4">
-          <svg className="h-8 w-8 text-garden-text/20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
-            <rect x="3" y="3" width="18" height="18" rx="2" />
-            <circle cx="8.5" cy="8.5" r="1.5" />
-            <path d="m21 15-5-5L5 21" />
-          </svg>
-          <span className="text-xs text-garden-text/30">{phase}</span>
-        </div>
-      )}
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-3 py-2">
-        <p className="text-xs text-garden-text/80">{label}</p>
-      </div>
-    </div>
-  )
-}
-
 export function JournalPage() {
-  const { slots, loading } = useJournal()
+  const { entries, loading, addEntry, deleteEntry, updateCaption } = useJournal()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading]   = useState(false)
+  const [openIndex, setOpenIndex]   = useState<number | null>(null)
+  const [dragging, setDragging]     = useState(false)
+  const dragDepth = useRef(0)
+
+  // Close the lightbox if the entry it was pointing at disappears (e.g. delete).
+  useEffect(() => {
+    if (openIndex === null) return
+    if (entries.length === 0) { setOpenIndex(null); return }
+    if (openIndex >= entries.length) setOpenIndex(entries.length - 1)
+  }, [entries.length, openIndex])
+
+  async function handleFiles(files: FileList | File[]) {
+    const list = Array.from(files).filter(f => f.type.startsWith('image/'))
+    if (list.length === 0) return
+    setUploading(true)
+    try {
+      // Upload sequentially so push-key timestamps stay distinct and ordered.
+      for (const file of list) await addEntry(file)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  function handlePaste(e: React.ClipboardEvent) {
+    const file = imageFromClipboard(e.nativeEvent)
+    if (file) handleFiles([file])
+  }
+
+  function handleDragEnter(e: React.DragEvent) {
+    if (!Array.from(e.dataTransfer.items ?? []).some(i => i.kind === 'file')) return
+    e.preventDefault()
+    dragDepth.current += 1
+    setDragging(true)
+  }
+  function handleDragOver(e: React.DragEvent) { e.preventDefault() }
+  function handleDragLeave() {
+    dragDepth.current -= 1
+    if (dragDepth.current <= 0) { dragDepth.current = 0; setDragging(false) }
+  }
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    dragDepth.current = 0
+    setDragging(false)
+    if (e.dataTransfer.files?.length) handleFiles(e.dataTransfer.files)
+  }
 
   return (
-    <div>
-      <PageHeader title="Journal" subtitle="Visual progress through each phase of the build" />
-      {loading ? <JournalSkeleton /> : (
+    <div
+      onPaste={handlePaste}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className="relative"
+    >
+      <div className="mb-6 flex items-end justify-between gap-4">
+        <PageHeader title="Journal" subtitle="Photos from the build — upload, browse, caption" />
+        <Button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+        >
+          {uploading ? 'Uploading…' : 'Add photo'}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={e => {
+            if (e.target.files?.length) handleFiles(e.target.files)
+            e.target.value = ''
+          }}
+        />
+      </div>
+
+      {loading ? (
+        <JournalSkeleton />
+      ) : entries.length === 0 ? (
+        <EmptyState
+          title="No photos yet"
+          description="Upload your first photo, paste from the clipboard, or drag an image onto this page."
+          action={
+            <Button onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+              {uploading ? 'Uploading…' : 'Add photo'}
+            </Button>
+          }
+        />
+      ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          {slots.map(slot => (
-            <PhotoSlot key={slot.id} label={slot.label} phase={slot.phase} imageUrl={slot.imageUrl} />
+          {entries.map((entry, i) => (
+            <button
+              key={entry.id}
+              onClick={() => setOpenIndex(i)}
+              className="group relative aspect-[3/2] overflow-hidden rounded border border-white/10 bg-[#1c2017] transition-transform hover:scale-[1.01] focus:outline-none focus:ring-2 focus:ring-amber/60"
+              data-testid="journal-tile"
+            >
+              <img
+                src={entry.imageUrl}
+                alt={entry.caption ?? 'Journal photo'}
+                className="h-full w-full object-cover"
+              />
+              {entry.caption && (
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-3 py-2 text-left">
+                  <p className="truncate text-xs text-garden-text/85">{entry.caption}</p>
+                </div>
+              )}
+            </button>
           ))}
         </div>
+      )}
+
+      {dragging && (
+        <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-black/40">
+          <div className="rounded border-2 border-dashed border-amber/60 bg-[#1c2017]/90 px-6 py-4 text-amber">
+            Drop image to upload
+          </div>
+        </div>
+      )}
+
+      {openIndex !== null && entries[openIndex] && (
+        <JournalLightbox
+          entries={entries}
+          index={openIndex}
+          onIndexChange={setOpenIndex}
+          onClose={() => setOpenIndex(null)}
+          onDelete={async (id) => { await deleteEntry(id) }}
+          onCaptionChange={(id, caption) => updateCaption(id, caption)}
+        />
       )}
     </div>
   )

--- a/src/lib/firebase/hooks.ts
+++ b/src/lib/firebase/hooks.ts
@@ -7,9 +7,9 @@ import type {
   Task, TaskStatus, TaskOption,
   Material, MaterialStatus, MaterialOption, OptionStatus,
   BudgetItem,
-  JournalSlot,
+  JournalEntry,
 } from '../../types'
-import { JOURNAL_SLOTS } from '../mock-data'
+import { storeJournalImage } from './storage'
 
 const DB_ROOT = import.meta.env.VITE_DB_ROOT ?? 'garden'
 
@@ -338,17 +338,90 @@ export function useBudget() {
 
 // ─── useJournal ───────────────────────────────────────────────────────────────
 
+// One-time migration map: legacy slot IDs → caption used after migration.
+// Newer slot order means newer createdAt (so newest-first sort puts the build
+// finale at the top).
+const LEGACY_SLOT_LABELS: Record<string, string> = {
+  before:      'Before — Current State',
+  groundworks: 'Groundworks — Dig & Level',
+  paving:      'Hard Landscaping — Paving',
+  pergola:     'Structures — Pergola Erected',
+  turf:        'Soft Landscaping — Turf Laid',
+  finished:    'Finished — Summer 2026',
+}
+const LEGACY_SLOT_ORDER = Object.keys(LEGACY_SLOT_LABELS)
+
+// Fire-and-forget. Runs at most once per page load; tolerates permission_denied
+// silently (legacy keys stay in the DB but are filtered out by the entry
+// validator in useJournal).
+let legacyMigrationAttempted = false
+function tryMigrateLegacySlots(data: Record<string, any>) {
+  if (legacyMigrationAttempted) return
+  legacyMigrationAttempted = true
+
+  const updates: Record<string, unknown> = {}
+  let needs = false
+  for (const slotId of LEGACY_SLOT_ORDER) {
+    const v = data[slotId]
+    if (!v || typeof v !== 'object') continue
+    if (v.imageUrl && v.createdAt == null) {
+      const newRef = push(ref(db, `${DB_ROOT}/journal`))
+      const idx    = LEGACY_SLOT_ORDER.indexOf(slotId)
+      const offset = (LEGACY_SLOT_ORDER.length - 1 - idx) * 86_400_000
+      updates[`${DB_ROOT}/journal/${newRef.key}`] = {
+        imageUrl:  v.imageUrl,
+        caption:   LEGACY_SLOT_LABELS[slotId],
+        createdAt: Date.now() - offset,
+      }
+      updates[`${DB_ROOT}/journal/${slotId}`] = null
+      needs = true
+    }
+  }
+  if (!needs) return
+  update(ref(db), updates).catch(() => { /* best effort */ })
+}
+
 export function useJournal() {
-  const [slots, setSlots] = useState<JournalSlot[]>([])
+  const [entries, setEntries] = useState<JournalEntry[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     return onValue(ref(db, `${DB_ROOT}/journal`), snap => {
       const data = snap.val() ?? {}
-      setSlots(JOURNAL_SLOTS.map(s => ({ ...s, imageUrl: data[s.id]?.imageUrl })))
+      tryMigrateLegacySlots(data)
+
+      const list: JournalEntry[] = (Object.entries(data) as [string, any][])
+        .filter(([, v]) =>
+          v && typeof v === 'object' && typeof v.imageUrl === 'string' && typeof v.createdAt === 'number'
+        )
+        .map(([id, v]) => ({
+          id,
+          imageUrl:  v.imageUrl,
+          caption:   v.caption,
+          createdAt: v.createdAt,
+        }))
+        .sort((a, b) => b.createdAt - a.createdAt)
+      setEntries(list)
       setLoading(false)
     })
   }, [])
 
-  return { slots, loading }
+  async function addEntry(file: File | Blob, caption?: string) {
+    const newRef   = push(ref(db, `${DB_ROOT}/journal`))
+    const id       = newRef.key!
+    const imageUrl = await storeJournalImage(file, id)
+    const payload: Omit<JournalEntry, 'id'> = { imageUrl, createdAt: Date.now() }
+    if (caption) payload.caption = caption
+    await set(newRef, payload)
+  }
+
+  async function deleteEntry(id: string) {
+    await remove(ref(db, `${DB_ROOT}/journal/${id}`))
+  }
+
+  async function updateCaption(id: string, caption: string) {
+    await update(ref(db, `${DB_ROOT}/journal/${id}`), { caption: caption || null })
+  }
+
+  return { entries, loading, addEntry, deleteEntry, updateCaption }
 }

--- a/src/lib/firebase/storage.ts
+++ b/src/lib/firebase/storage.ts
@@ -55,6 +55,26 @@ export async function storeOptionImage(
   return getDownloadURL(sRef)
 }
 
+/**
+ * Compress and store a journal image.
+ * - ≤ 100KB compressed → store as data URL (returned directly)
+ * - > 100KB → upload to Firebase Storage at journal/{entryId}.jpg
+ */
+export async function storeJournalImage(file: File | Blob, entryId: string): Promise<string> {
+  const dataUrl  = await compressImage(file)
+  const byteSize = Math.round((dataUrl.length * 3) / 4)
+
+  if (byteSize <= 100 * 1024) {
+    return dataUrl
+  }
+
+  const res  = await fetch(dataUrl)
+  const blob = await res.blob()
+  const sRef = storageRef(storage, `journal/${entryId}.jpg`)
+  await uploadBytes(sRef, blob, { contentType: 'image/jpeg' })
+  return getDownloadURL(sRef)
+}
+
 /** Extract an image File from a paste ClipboardEvent. Returns null if no image found. */
 export function imageFromClipboard(e: ClipboardEvent): File | null {
   const items = Array.from(e.clipboardData?.items ?? [])

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { Phase, Material, BudgetItem, JournalSlot, Zone } from '../types'
+import type { Phase, Material, BudgetItem, Zone } from '../types'
 
 // ─── Phases ──────────────────────────────────────────────────────────────────
 
@@ -174,17 +174,6 @@ export const BUDGET_ITEMS: BudgetItem[] = [
   { id: 'breaker',    name: 'Breaker Hire (2 weekends)',                  low:  172, high:  172 },
   { id: 'weedkiller', name: 'Weedkiller',                                low:   30, high:   60 },
   { id: 'fence-trellis', name: 'Right Fence Trellis',                   low:    0, high:    0 },
-]
-
-// ─── Journal ─────────────────────────────────────────────────────────────────
-
-export const JOURNAL_SLOTS: JournalSlot[] = [
-  { id: 'before',      label: 'Before — Current State',        phase: 'Phase 0' },
-  { id: 'groundworks', label: 'Groundworks — Dig & Level',     phase: 'Phase 1' },
-  { id: 'paving',      label: 'Hard Landscaping — Paving',     phase: 'Phase 2' },
-  { id: 'pergola',     label: 'Structures — Pergola Erected',  phase: 'Phase 3' },
-  { id: 'turf',        label: 'Soft Landscaping — Turf Laid',  phase: 'Phase 4' },
-  { id: 'finished',    label: 'Finished — Summer 2026',        phase: 'Phase 5' },
 ]
 
 // ─── Map zones ───────────────────────────────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,11 +76,11 @@ export interface BudgetItem {
 
 // ─── Journal ─────────────────────────────────────────────────────────────────
 
-export interface JournalSlot {
+export interface JournalEntry {
   id:        string
-  label:     string
-  phase:     string
-  imageUrl?: string
+  imageUrl:  string
+  caption?:  string
+  createdAt: number
 }
 
 // ─── Map ─────────────────────────────────────────────────────────────────────

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -110,10 +110,29 @@ test('Materials: status badges render', async ({ page }) => {
   await expect(page.getByText('Researching').first()).toBeVisible()
 })
 
-test('Journal: photo slots render', async ({ page }) => {
+test('Journal: page renders with add-photo affordance', async ({ page }) => {
   await page.goto('/journal')
-  await expect(page.getByText('Before — Current State')).toBeVisible()
-  await expect(page.getByText('Finished — Summer 2026')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Journal', level: 1 })).toBeVisible()
+  await expect(page.getByRole('button', { name: /add photo/i }).first()).toBeVisible()
+})
+
+test('Journal: file input accepts multiple images', async ({ page }) => {
+  await page.goto('/journal')
+  const input = page.locator('input[type="file"]')
+  await expect(input).toHaveAttribute('accept', 'image/*')
+  await expect(input).toHaveAttribute('multiple', '')
+})
+
+test('Journal: drag-over shows drop overlay', async ({ page }) => {
+  await page.goto('/journal')
+  await page.waitForSelector('h1:has-text("Journal")')
+  // Dispatch on the heading so the dragenter event bubbles up to the wrapper's handler.
+  await page.locator('h1:has-text("Journal")').evaluate(el => {
+    const dt = new DataTransfer()
+    dt.items.add(new File(['x'], 'x.png', { type: 'image/png' }))
+    el.dispatchEvent(new DragEvent('dragenter', { bubbles: true, dataTransfer: dt }))
+  })
+  await expect(page.getByText('Drop image to upload')).toBeVisible()
 })
 
 test('Map: SVG garden plan renders', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replace the fixed 6-slot phased journal with an open list of `JournalEntry` records keyed by Firebase push IDs
- Upload via "Add photo" button, clipboard paste, or page-level drag-and-drop
- Tile grid (newest first) with optional captions; full-screen lightbox with prev/next chevrons, ←/→ keys, inline caption editing, and delete-with-confirm
- One-shot, fail-tolerant migration converts the legacy slot photos into entries (preserving phase labels as captions) on the first signed-in load
- New `storeJournalImage` mirrors `storeOptionImage`: ≤100KB stays as a data URL in RTDB; larger uploads go to Storage at `journal/{entryId}.jpg`

## Test plan
- [x] `npm run build` clean
- [x] Full Playwright suite green (55/55)
- [x] New tests cover: page render + Add photo button, file input config (`accept="image/*"`, `multiple`), drag-over drop overlay
- [ ] Manual: signed-in user uploads a small (<100KB compressed) image and a larger one; both appear in the grid and persist
- [ ] Manual: legacy 6 slot photos appear as captioned entries on first load
- [ ] Manual: lightbox prev/next navigation, caption edit, delete-with-confirm

## Prerequisites (handled out of band)
- Firebase Storage rules updated to cover `journal/{allPaths=**}` with auth-protected writes
- Storage rule path renamed from `optionImages/` to `options/` to match existing code (silently fixes large material photo uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)