### PR TITLE
fix: use signInWithRedirect so popup-blocking browsers can sign in

### DIFF
--- a/src/app/AuthProvider.tsx
+++ b/src/app/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { onAuthStateChanged, signOut as firebaseSignOut, type User } from 'firebase/auth'
-import { auth, signInWithGoogle, signOutUser } from '../lib/firebase/auth'
+import { auth, signInWithGoogle, signOutUser, getGoogleRedirectResult } from '../lib/firebase/auth'
 
 interface AuthContextValue {
   user:    User | null
@@ -30,6 +30,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       firebaseSignOut(auth)
       return
     }
+    // Process redirect token after returning from the Google sign-in page.
+    // onAuthStateChanged fires once Firebase finishes settling.
+    getGoogleRedirectResult().catch(() => {})
     return onAuthStateChanged(auth, u => {
       if (u && ALLOWED_EMAILS.size > 0 && !ALLOWED_EMAILS.has(u.email ?? '')) {
         firebaseSignOut(auth)

--- a/src/lib/firebase/auth.ts
+++ b/src/lib/firebase/auth.ts
@@ -1,11 +1,15 @@
-import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth'
+import { getAuth, GoogleAuthProvider, signInWithRedirect, getRedirectResult, signOut } from 'firebase/auth'
 import { app } from './config'
 
 export const auth = getAuth(app)
 const provider = new GoogleAuthProvider()
 
 export function signInWithGoogle() {
-  return signInWithPopup(auth, provider)
+  return signInWithRedirect(auth, provider)
+}
+
+export function getGoogleRedirectResult() {
+  return getRedirectResult(auth)
 }
 
 export function signOutUser() {


### PR DESCRIPTION
## Summary
- Switch sign-in flow from \`signInWithPopup\` → \`signInWithRedirect\`
- Add \`getRedirectResult()\` call in AuthProvider so Firebase processes the redirect token on return; \`onAuthStateChanged\` then fires as usual
- Same approach as commit \`eed6b6d\` (which was reverted in \`682f0e7\` after popup was thought to be configured); Dia/Arc/Brave/Safari-ITP still close the popup before the credential reaches the parent window

## Test plan
- [x] \`npm run build\` clean
- [ ] Sign in from production URL in Dia: Google chooser opens in same tab → returns to \`/\` signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)