### PR TITLE
test: deeper journal tests — lightbox, nav, caption, delete, upload

### DIFF
--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -66,5 +66,17 @@ for (const [i, m] of MATERIALS.entries()) {
 }
 console.log(`  ✓ ${DB_ROOT}/materials (${MATERIALS.length} materials)`)
 
-// Journal — seeded empty; entries are created at runtime via uploads.
+// Journal — seed two entries so tests can exercise the lightbox flow
+// (open, prev/next, caption edit, delete-with-confirm).
+const PIXEL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+const journalEntries = [
+  // Older first; newest-first sort means the second entry shows at index 0
+  { id: 'test-entry-old', imageUrl: PIXEL, caption: 'First test photo',  createdAt: 1_700_000_000_000 },
+  { id: 'test-entry-new', imageUrl: PIXEL, caption: 'Second test photo', createdAt: 1_700_000_001_000 },
+]
+for (const e of journalEntries) {
+  await put(`journal/${e.id}`, { imageUrl: e.imageUrl, caption: e.caption, createdAt: e.createdAt })
+}
+console.log(`  ✓ ${DB_ROOT}/journal (${journalEntries.length} entries)`)
+
 console.log('Done.')

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -135,6 +135,61 @@ test('Journal: drag-over shows drop overlay', async ({ page }) => {
   await expect(page.getByText('Drop image to upload')).toBeVisible()
 })
 
+// The lightbox tests below assume seeded journal entries exist in the test DB
+// (see scripts/seed-test-db.ts). They run against garden-test in CI.
+
+test('Journal: clicking a tile opens the lightbox', async ({ page }) => {
+  await page.goto('/journal')
+  await page.getByTestId('journal-tile').first().waitFor()
+  await page.getByTestId('journal-tile').first().click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+})
+
+test('Journal: arrow keys navigate between photos in the lightbox', async ({ page }) => {
+  await page.goto('/journal')
+  await page.getByTestId('journal-tile').first().waitFor()
+  await page.getByTestId('journal-tile').first().click()
+  await expect(page.getByText('1 / 2')).toBeVisible()
+  await page.keyboard.press('ArrowRight')
+  await expect(page.getByText('2 / 2')).toBeVisible()
+  await page.keyboard.press('ArrowLeft')
+  await expect(page.getByText('1 / 2')).toBeVisible()
+})
+
+test('Journal: editing the caption persists optimistically', async ({ page }) => {
+  await page.goto('/journal')
+  await page.getByTestId('journal-tile').first().waitFor()
+  await page.getByTestId('journal-tile').first().click()
+  await page.getByTestId('journal-caption-display').click()
+  const input = page.getByTestId('journal-caption-input')
+  await input.fill('Edited caption')
+  await input.press('Enter')
+  await expect(page.getByTestId('journal-caption-display')).toContainText('Edited caption')
+})
+
+test('Journal: delete photo opens confirm modal', async ({ page }) => {
+  await page.goto('/journal')
+  await page.getByTestId('journal-tile').first().waitFor()
+  await page.getByTestId('journal-tile').first().click()
+  await page.getByRole('button', { name: 'Delete photo' }).click()
+  await expect(page.getByText(/permanently remove/i)).toBeVisible()
+})
+
+test('Journal: uploading a photo via the hidden input adds a new tile', async ({ page }) => {
+  await page.goto('/journal')
+  await page.getByTestId('journal-tile').first().waitFor()
+  const before = await page.getByTestId('journal-tile').count()
+  await page.locator('input[type="file"]').first().setInputFiles({
+    name: 'pixel.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+      'base64',
+    ),
+  })
+  await expect(page.getByTestId('journal-tile')).toHaveCount(before + 1)
+})
+
 test('Map: SVG garden plan renders', async ({ page }) => {
   await page.goto('/map')
   await expect(page.locator('svg#garden-svg')).toBeVisible()


### PR DESCRIPTION
## Summary
Closes out journal coverage with five new tests now that Firebase rules permit writes:

- Tile click opens the lightbox dialog
- ←/→ keys navigate between photos (verified via the \`1 / 2\` index counter)
- Caption click → inline editor → Enter → caption updates optimistically
- Delete button opens the ConfirmModal
- Upload via the hidden file input adds a tile

Seed script seeds two pixel-data-URL journal entries so the tests have data to interact with.

## Test plan
- [x] \`npm run test:local\` — full suite green (60/60) after a fresh seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)